### PR TITLE
Restrict block range on queries

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,3 +1,4 @@
 export * from './listPrintHolders'
 export * from './originalOwnershipHistory'
 export * from './royalties'
+export * from './snapshot'

--- a/src/actions/snapshot.ts
+++ b/src/actions/snapshot.ts
@@ -1,0 +1,118 @@
+import { Command, CommanderError, OptionValues } from 'commander'
+import { BigNumberish } from 'ethers'
+import { padStart, sum } from 'lodash'
+import { table } from 'table'
+import { printOwnership } from '../lib'
+import { initializeProvider } from '../config'
+import {
+    deployBlockForRelease,
+    TokenOwnership,
+    trackNumberToOriginalTokenId,
+    OriginalEulerBeat,
+    CACHE_DIR,
+    tableConfig,
+    contractAndTokenId,
+} from '../utils'
+import { EthCallOptions, Release } from '../types'
+import { stakedBalances } from '../lib/staking'
+import { getAllRecipients, getTokenBalances } from '../lib/erc1155'
+
+
+function csvOutput(owners: any) {
+    let data = 'Address,Balance\n'
+    console.log('Address,Balance')
+
+    for (const addy of Object.keys(owners)) {
+        const balance = owners[addy]
+        if (balance > 0) {
+            data = data.concat(`${addy},${balance}\n`)
+            console.log(`${addy},${balance}`)
+        }
+    }
+}
+
+
+async function handler(options: OptionValues, command: Command) {
+    const provider = await initializeProvider(options.rpc)
+
+    
+    let targetBlock
+    try {
+        targetBlock = parseInt(options.block)
+    } catch (e) {
+        // swallow
+    }
+    
+    if (!targetBlock) {
+        targetBlock = await provider.getBlockNumber();
+    }
+
+    const possibleAddresses = new Set<string>();
+    console.log(`Loading candidate genesis holders at block ${targetBlock}`)
+    const genesisAddresses = await getAllRecipients(Release.genesis, undefined, targetBlock);
+    console.log(`Found ${genesisAddresses.length}`)
+
+    console.log(`Loading candidate enigma holders at block ${targetBlock}`)
+    const enigmaAddresses = await getAllRecipients(Release.enigma, undefined, targetBlock);
+    console.log(`Found ${enigmaAddresses.length}`)
+    
+    genesisAddresses.forEach(addy => possibleAddresses.add(addy))
+    enigmaAddresses.forEach(addy => possibleAddresses.add(addy))
+
+    console.log(`Found ${possibleAddresses.size} unique addresses who have ever received a EB original/print at block ${targetBlock}.  Now checking balances at block ${targetBlock} for all these addresses, this will take a while...`)
+
+    // we have all addresses that have received a token, get their current balances
+    const balances = {}
+
+    const web3Options: EthCallOptions = {
+        blockTag: targetBlock
+    }
+    
+    for (let i = 1; i <= 27; i++) {        
+        const trackNumber = padStart(i.toString(), 2, "0")
+        
+        const genesisTrack = contractAndTokenId(Release.genesis, trackNumber)
+        const enigmaTrack = contractAndTokenId(Release.enigma, trackNumber)
+
+        console.log(`Loading genesis holder info for track ${trackNumber} at block ${targetBlock}`)
+        const genesisOriginalHolders = await getTokenBalances(genesisTrack.contractAddress, genesisTrack.originalTokenId, genesisAddresses, web3Options)
+        const genesisPrintHolders = await getTokenBalances(genesisTrack.contractAddress, genesisTrack.printTokenId, genesisAddresses, web3Options)
+        
+        console.log(`Loading enigma holder info for track ${trackNumber} at block ${targetBlock}`)
+        const enigmaOriginalHolders = await getTokenBalances(enigmaTrack.contractAddress, enigmaTrack.originalTokenId, enigmaAddresses, web3Options)
+        const enigmaPrintHolders = await getTokenBalances(enigmaTrack.contractAddress, enigmaTrack.printTokenId, enigmaAddresses, web3Options)
+
+        for (let i = 0; i < genesisAddresses.length; i++) {
+            const addy = genesisAddresses[i]
+            const balance = genesisOriginalHolders[i].add(genesisPrintHolders[i]).toNumber()
+            if (!(addy in balances)) {
+                balances[addy] = 0
+            }
+            balances[addy] += balance
+        }
+
+        for (let i = 0; i < enigmaAddresses.length; i++) {
+            const addy = enigmaAddresses[i]
+            const balance = enigmaOriginalHolders[i].add(enigmaPrintHolders[i]).toNumber()
+            if (!(addy in balances)) {
+                balances[addy] = 0
+            }
+            balances[addy] += balance
+        }
+
+        console.log(`Loading staked holder info for pairs of track ${trackNumber} at block ${targetBlock}`)
+        const pairStakers = await stakedBalances(Release.genesis, trackNumber, web3Options)
+        for (let addy of Object.keys(pairStakers)) {
+            if (!(addy in balances)) {
+                balances[addy] = 0
+            }
+
+            balances[addy] += (pairStakers[addy] * 2)
+        }
+    }
+
+    csvOutput(balances)
+    
+}
+
+export { handler as snapshotHolders }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
     originalOwnershipHistory,
     listPrintHolders,
     royaltiesAction,
+    snapshotHolders,
 } from './actions'
 
 dotenv.config()
@@ -82,9 +83,28 @@ function addPrintsCommand() {
 }
 
 
+function addSnapshotCommand() {
+    const printsCommand = program
+        .command('snapshot')
+        .description('Takes a snapshot of all holders for all tokens')
+        .addOption(rpcProviderOption())
+        .addOption(blockOption())
+        .addOption(
+            new Option(
+                '-o, --output <format>',
+                'The format of the output, either table (default) or csv.'
+            )
+                .choices(['table', 'csv'])
+                .default('table')
+        )
+        .action(snapshotHolders)
+}
+
+
 async function main() {
     addOriginalsCommand()
     addPrintsCommand()
+    addSnapshotCommand()
 
     await program.parseAsync()
 }

--- a/src/lib/prints.ts
+++ b/src/lib/prints.ts
@@ -21,7 +21,6 @@ export async function printOwnership(
         options
     )
 
-    // get the stakers if desired too
     let stakers
     if (includeStakers) {
         stakers = await stakedBalances(release, trackNumber, options)

--- a/src/lib/staking.ts
+++ b/src/lib/staking.ts
@@ -1,10 +1,10 @@
-import { getAllRecipients } from './erc1155'
 import { EthCallOptions, Release } from '../types'
 import { contractAndTokenId, getStakingContract } from '../utils'
 import { BigNumber } from '@ethersproject/bignumber'
 
 
 const STAKING_DEPLOY_BLOCK = 12375826
+const MAX_BLOCKS_PER_QUERY = 100_000
 
 
 export async function stakedBalances(
@@ -15,17 +15,39 @@ export async function stakedBalances(
     const { contractAddress, printTokenId } = contractAndTokenId(release, trackNumber)
 
     const contract = await getStakingContract()
+    let blockNumber;
+    if (options && options.blockTag && options.blockTag !== 'latest') {
+        blockNumber = options.blockTag
+    } else {
+        blockNumber = await contract.provider.getBlockNumber()
+    }
 
     // get staking event for this track
     const pairNumber = BigNumber.from(trackNumber).sub(1).toNumber()
     const filter = contract.filters.PairStaked(pairNumber, null, null)
-    const events = await contract.queryFilter(filter, STAKING_DEPLOY_BLOCK, options?.blockTag || 'latest')
+
+    const addresses = new Set<string>()
+
+    let startBlock = STAKING_DEPLOY_BLOCK;
+
+    while (startBlock < blockNumber) {
+        const endBlock = Math.min(startBlock + MAX_BLOCKS_PER_QUERY, blockNumber)
+        const events = await contract.queryFilter(filter, startBlock, endBlock)
+
+        for (let event of events) {
+            addresses.add(event.args!.account)
+        }
+        startBlock += MAX_BLOCKS_PER_QUERY
+    }
 
     const balances = {}
-    for (let event of events) {
-        const address = event.args!.account
+    for (let address of addresses) {
         const addressBalance = await contract.balanceOf(address, contractAddress, printTokenId, options || {})
-        balances[address] = addressBalance.toNumber()
+        const balance = addressBalance.toNumber()
+        if (balance > 0) {
+            balances[address] = balance;
+        }
+        
     }
 
     return balances


### PR DESCRIPTION
Avoid querying excessively large ranges or blocks, instead issue multiple queries over smaller range of blocks.